### PR TITLE
Set latest working platform version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ board_build.f_cpu = 80000000L
 upload_speed = 921600
 monitor_speed = 115200
 lib_deps =
-    Wire
+    Wire@2.0.0
     https://github.com/Xinyuan-LilyGO/LilyGo-EPD47.git
     bblanchon/ArduinoJson@6.17.3
     PubSubClient 
@@ -32,7 +32,7 @@ build_flags =
     -DBOARD_HAS_PSRAM
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@6.8.1
 board = esp32dev
 framework = ${common_env_data.framework}
 upload_speed = ${common_env_data.upload_speed}


### PR DESCRIPTION
The latest version of espressif32 (6.9.0) was not working with code and LilyGo-EPD47 library. 

Explicitly specified latest working version.